### PR TITLE
feat: add the validate for DirectoryLoader

### DIFF
--- a/loader/directory.go
+++ b/loader/directory.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/henomis/lingoose/document"
 
@@ -33,6 +34,11 @@ func (d *DirectoryLoader) WithTextSplitter(textSplitter TextSplitter) *Directory
 
 func (d *DirectoryLoader) Load(ctx context.Context) ([]document.Document, error) {
 
+	err := d.validate()
+	if err != nil {
+		return nil, err
+	}
+
 	regExp, err := regexp.Compile(d.regExPathMatch)
 	if err != nil {
 		return nil, err
@@ -61,4 +67,18 @@ func (d *DirectoryLoader) Load(ctx context.Context) ([]document.Document, error)
 	}
 
 	return docs, nil
+}
+
+func (d *DirectoryLoader) validate() error {
+
+	fileStat, err := os.Stat(d.dirname)
+	if err != nil {
+		return fmt.Errorf("%s: %w", ErrorInternal, err)
+	}
+
+	if !fileStat.IsDir() {
+		return fmt.Errorf("%s: %w", ErrorInternal, os.ErrNotExist)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description
Add a basic validate for loader.DirectoryLoader like other loaders. 
It's easy to set a mistake directory path, yet there are no error prompts.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Simple unit test at local branch
