### PR TITLE
fix: stackoverflow caused by textspliter

### DIFF
--- a/textsplitter/recursiveTextSplitter.go
+++ b/textsplitter/recursiveTextSplitter.go
@@ -68,10 +68,15 @@ func (r *RecursiveCharacterTextSplitter) SplitText(text string) []string {
 	finalChunks := []string{}
 	// Get appropriate separator to use
 	separator := r.separators[len(r.separators)-1]
-	newSeparators := []string{}
-	for i, c := range r.separators {
-		if c == "" || strings.Contains(text, c) {
-			separator = c
+        newSeparators := []string{}
+	for i, s := range r.separators {
+		if s == "" {
+			separator = s
+			break
+		}
+
+		if strings.Contains(text, s) {
+			separator = s
 			newSeparators = r.separators[i+1:]
 			break
 		}

--- a/textsplitter/recursiveTextSplitter.go
+++ b/textsplitter/recursiveTextSplitter.go
@@ -68,7 +68,7 @@ func (r *RecursiveCharacterTextSplitter) SplitText(text string) []string {
 	finalChunks := []string{}
 	// Get appropriate separator to use
 	separator := r.separators[len(r.separators)-1]
-        newSeparators := []string{}
+	newSeparators := []string{}
 	for i, s := range r.separators {
 		if s == "" {
 			separator = s

--- a/textsplitter/recursiveTextSplitter.go
+++ b/textsplitter/recursiveTextSplitter.go
@@ -82,8 +82,7 @@ func (r *RecursiveCharacterTextSplitter) SplitText(text string) []string {
 		}
 	}
 	// Now that we have the separator, split the text
-	var splits []string
-	splits = strings.Split(text, separator)
+	splits := strings.Split(text, separator)
 	// Now go merging things, recursively splitting longer texts.
 	goodSplits := []string{}
 	for _, s := range splits {

--- a/textsplitter/recursiveTextSplitter.go
+++ b/textsplitter/recursiveTextSplitter.go
@@ -83,7 +83,7 @@ func (r *RecursiveCharacterTextSplitter) SplitText(text string) []string {
 	}
 	// Now that we have the separator, split the text
 	var splits []string
-	splits = strings.Split(text, "")
+	splits = strings.Split(text, separator)
 	// Now go merging things, recursively splitting longer texts.
 	goodSplits := []string{}
 	for _, s := range splits {

--- a/textsplitter/recursiveTextSplitter.go
+++ b/textsplitter/recursiveTextSplitter.go
@@ -83,11 +83,7 @@ func (r *RecursiveCharacterTextSplitter) SplitText(text string) []string {
 	}
 	// Now that we have the separator, split the text
 	var splits []string
-	if separator != "" {
-		splits = strings.Split(text, separator)
-	} else {
-		splits = strings.Split(text, "")
-	}
+	splits = strings.Split(text, "")
 	// Now go merging things, recursively splitting longer texts.
 	goodSplits := []string{}
 	for _, s := range splits {

--- a/textsplitter/recursiveTextSplitter.go
+++ b/textsplitter/recursiveTextSplitter.go
@@ -68,13 +68,11 @@ func (r *RecursiveCharacterTextSplitter) SplitText(text string) []string {
 	finalChunks := []string{}
 	// Get appropriate separator to use
 	separator := r.separators[len(r.separators)-1]
-	for _, s := range r.separators {
-		if s == "" {
-			separator = s
-			break
-		}
-		if strings.Contains(text, s) {
-			separator = s
+	newSeparators := []string{}
+	for i, c := range r.separators {
+		if c == "" || strings.Contains(text, c) {
+			separator = c
+			newSeparators = r.separators[i+1:]
 			break
 		}
 	}
@@ -96,8 +94,12 @@ func (r *RecursiveCharacterTextSplitter) SplitText(text string) []string {
 				finalChunks = append(finalChunks, mergedText...)
 				goodSplits = []string{}
 			}
-			otherInfo := r.SplitText(s)
-			finalChunks = append(finalChunks, otherInfo...)
+			if len(newSeparators) == 0 {
+				finalChunks = append(finalChunks, s)
+			} else {
+				otherInfo := r.SplitText(s)
+				finalChunks = append(finalChunks, otherInfo...)
+			}
 		}
 	}
 	if len(goodSplits) > 0 {

--- a/textsplitter/recursiveTextSplitter_test.go
+++ b/textsplitter/recursiveTextSplitter_test.go
@@ -3,11 +3,13 @@ package textsplitter
 import (
 	"reflect"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/henomis/lingoose/document"
 	"github.com/henomis/lingoose/types"
 )
 
+//nolint:dupword,funlen
 func TestRecursiveCharacterTextSplitter_SplitDocuments(t *testing.T) {
 	type fields struct {
 		textSplitter TextSplitter
@@ -49,6 +51,66 @@ func TestRecursiveCharacterTextSplitter_SplitDocuments(t *testing.T) {
 				},
 				{
 					Content:  "test",
+					Metadata: types.Meta{},
+				},
+			},
+		},
+		{
+			name: "TestRecursiveCharacterTextSplitter_SplitDocuments",
+			fields: fields{
+				textSplitter: TextSplitter{
+					chunkSize:    20,
+					chunkOverlap: 1,
+					lengthFunction: func(s string) int {
+						return len(s)
+					},
+				},
+				separators: []string{"\n", "$"},
+			},
+			args: args{
+				documents: []document.Document{
+					{
+						Content:  "Hi, Harrison. \nI am glad to meet you",
+						Metadata: types.Meta{},
+					},
+				},
+			},
+			want: []document.Document{
+				{
+					Content:  "Hi, Harrison.",
+					Metadata: types.Meta{},
+				},
+				{
+					Content:  "I am glad to meet you",
+					Metadata: types.Meta{},
+				},
+			},
+		},
+		{
+			name: "TestRecursiveCharacterTextSplitter_SplitDocuments",
+			fields: fields{
+				textSplitter: TextSplitter{
+					chunkSize:      10,
+					chunkOverlap:   0,
+					lengthFunction: utf8.RuneCountInString,
+				},
+				separators: []string{"\n\n", "\n", " "},
+			},
+			args: args{
+				documents: []document.Document{
+					{
+						Content:  "哈里森\n很高兴遇见你\n欢迎来中国",
+						Metadata: types.Meta{},
+					},
+				},
+			},
+			want: []document.Document{
+				{
+					Content:  "哈里森\n很高兴遇见你",
+					Metadata: types.Meta{},
+				},
+				{
+					Content:  "欢迎来中国",
 					Metadata: types.Meta{},
 				},
 			},


### PR DESCRIPTION
# Pull Request Template

## Description

When separators do not include "", textspliter may result in infinite recursive calls, i.e., stack overflow.
Here's an example:
The input parameters are:
```
rc := RecursiveCharacter{
    Separators: []string{"\n", "$"},
    ChunkSize:  20,
    ChunkOverlap: 1,
}
text := "Hi, Harrison. \nI am glad to meet you"
```

error like this:
```
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc02081e330 stack=[0xc02081e000, 0xc04081e000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x358d8ae?, 0x0?})
/usr/local/go/src/runtime/panic.go:1023 +0x5c fp=0x7ff7bdc6e270 sp=0x7ff7bdc6e240 pc=0x32cab7c
runtime.newstack()
/usr/local/go/src/runtime/stack.go:1103 +0x5bd fp=0x7ff7bdc6e420 sp=0x7ff7bdc6e270 pc=0x32e6a1d
runtime.morestack()
/usr/local/go/src/runtime/asm_amd64.s:616 +0x7a fp=0x7ff7bdc6e428 sp=0x7ff7bdc6e420 pc=0x3302dda
```



## Type of change

- [x] Bug fix 


Add the newSeparators array to avoid entering an infinite loop call.
Inspired by https://github.com/langchain-ai/langchain/blob/00a09e1b7117f3bde14a44748510fcccc95f9de5/libs/langchain/langchain/text_splitter.py.
